### PR TITLE
add logs/.gitkeep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ tmp
 ### https://raw.github.com/github/gitignore/4488915eec0b3a45b5c63ead28f286819c0917de/Node.gitignore
 
 # Logs
-logs
 *.log
 npm-debug.log*
 yarn-debug.log*
@@ -135,4 +134,5 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
-
+logs/*
+!logs/.gitkeep


### PR DESCRIPTION
The following error occurred when executing the command.

```
$ npx ts-node index.ts > logs/credentials.jsonl
zsh: no such file or directory: logs/credentials.jsonl
```