### PR TITLE
Fixed JSON Output

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -130,13 +130,13 @@ const app = async () => {
   connectedProjects.forEach(async (projectName) => {
     const envVars = await getProjectEnvvars(projectName);
     const configAWS = await getProjectSettings(projectName);
-    console.log(`{ "project": "${projectName}", "envVars": ${JSON.stringify(envVars)}, "awsConfig": ${JSON.stringify(configAWS)}},`);
+    console.log(JSON.stringify({ project: projectName, envVars: envVars, awsConfig: configAWS }));
   });
   // Contexts
   const contexts = await getContexts();
   contexts.forEach(async (context) => {
     const items = await getContextEnvvars(context.id);
-    console.log(`{context: ${context.name}, items: ${JSON.stringify(items)}}`);
+    console.log(JSON.stringify({ context: context.name, items: items }));
   });
 };
 app();


### PR DESCRIPTION
## Synopsis

Lines 133 and 139 both produce malformed JSON. Fixed this by calling `JSON.stringify` on the entire object.

## JSON for Projects

### Current Output
```json
{ "project": "foo", "envVars": ["bar","baz"], "awsConfig": undefined },
```

This is malformed because `JSON.stringify(undefined)` doesn't produce valid JSON, and because of the trailing comma.

### New Output

```json
{"project":"foo","envVars":["bar","baz"]}
```

Note that `JSON.stringify` removes any keys with `undefined` value. Let me know if they should be kept (as `null` or `[]` etc) and I can update this PR.

## JSON for Contexts

### Current Output
```json
{context: foo, items: ["bar","baz"]}
```

This is malformed because of bare words.

### New Output

```json
{"context":"foo","items":["bar","baz"]}
```